### PR TITLE
Small fixes and enhancements based on feedback

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 
 python:
+- 3.4
 - 3.5
 - 3.5-dev
 - 3.6

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ CARMIN-server is a lightweight server implementation of the [CARMIN API](https:/
   - [Database](#database)
   - [Installing Locally](#installing-locally)
   - [Installing with Docker](#installing-with-docker)
+  - [Common Installation Problems](#common-installation-problems)
+  	  - [pg_config](#pg_config)
 - [Usage](#usage)
   - [Authentication](#authentication)
   	  - [Creating Accounts](#creating-accounts)
@@ -80,6 +82,12 @@ docker run -p 8080:8080 \
 		   -v $DATA_DIRECTORY:/carmin-assets/data \
 		   carmin-server
 ```
+
+### Common Installation Problems
+
+#### pg_config
+
+The server launch might fail due to a missing `pg_config` installation on the computer. To fix this, download `libpq-dev` using your distro's package manager. (On Red Hat and derived distributions, install `postgresql-devel`)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ CARMIN-server is a lightweight server implementation of the [CARMIN API](https:/
   - [Installing with Docker](#installing-with-docker)
 - [Usage](#usage)
   - [Authentication](#authentication)
+  	  - [Creating Accounts](#creating-accounts)
+  	  - [Changing Your Password](#changing-your-password)
   - [Uploading Data to the Server](#uploading-data-to-the-server)
   - [Getting Data from the Server](#getting-data-from-the-server)
   - [Adding a Pipeline](#adding-a-pipeline)
@@ -106,6 +108,44 @@ for authenticated queries.
 ```
 
 In subsequent requests, all we have to do is include the `apiKey` in the headers.
+
+#### Creating Accounts
+
+To add new users to the database, an admin must send a `POST` request at the `/users/register` endpoint. The admin must include both `username` and `password` in the request body.
+
+Example:
+```
+curl -X "POST" "http://localhost:8080/users/register" \
+     -H 'apiKey: [secret-api-key]' \
+     -d $'{
+  "username": "new-user",
+  "password": "user-password"
+}'
+```
+
+#### Changing Your Password
+
+Passwords can be changed by sending a `POST` request to the `/users/edit` endpoint.
+Admins can change passwords for any user, and regular users can only change their own. To change a user's password, an admin must include both the `username` and `password` in the request body. For a user to change his/her own password, only the `password` is required.
+
+Example (Admin):
+```
+curl -X "POST" "http://localhost:8080/users/edit" \
+     -H 'apiKey: [secret-admin-api-key]' \
+     -d $'{
+  "username": "some-user",
+  "password": "new-password"
+}'
+```
+
+Example (Regular User):
+```
+curl -X "POST" "http://localhost:8080/users/edit" \
+     -H 'apiKey: [secret-api-key]' \
+     -d $'{
+  "password": "new-password"
+}'
+```
 
 ### Uploading Data to the Server
 Let's add some data to the server with the `PUT /path/{completePath}` method:

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ must be placed inside a `boutiques` directory, as such:
 
 ### Database
 
-By default, `CARMIN-server` uses a lightweight `sqlite` database that does not require any setup. `CARMIN-server` also natively supports a `postgres` database. If you'd like to use an external `postgres` database, simply set a `$DATABASE_URL` environment variable to point to the production database URL.
+By default, `CARMIN-server` uses a lightweight `sqlite` database that does not require any setup. `CARMIN-server` also natively supports a `postgres` database. If you'd like to use an external `postgres` database, simply set a `$DATABASE_URI` environment variable to point to the production database URL.
 ```bash
-$ export DATABASE_URL=postgresql://user:password@localhost/carmin
+$ export DATABASE_URI=postgresql://user:password@localhost/carmin
 ```
 
 ### Installing Locally

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Add this descriptor file in `$PIPELINE_DIRECTORY/boutiques`:
         {
             "id": "output_file",
             "name": "Output file",
-            "path-template": "[INPUT_FILE]-greeting.txt",
+            "path-template": "./greeting.txt",
             "path-template-stripped-extensions": [
                 ".txt",
                 ".mnc",

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ docker run -p 8080:8080 \
 
 ## Usage
 
-CARMIN-server automatically creates an admin user with `admin` as username and password.
+CARMIN-server automatically creates an admin user with `admin` as username. The password is printed to the console upon launching the server for the first time.
 
 You can get your `apiKey` by authenticating into the system:
 
@@ -92,7 +92,7 @@ You can get your `apiKey` by authenticating into the system:
 curl -X "POST" "http://localhost:8080/authenticate" \
      -d $'{
   "username": "admin",
-  "password": "admin"
+  "password": "[default-admin-password]"
 }'
 
 ```

--- a/server/api.py
+++ b/server/api.py
@@ -7,6 +7,7 @@ def declare_api(app):
     from server.startup_validation import start_up
     from server.resources.authenticate import Authenticate
     from server.resources.register import Register
+    from server.resources.edit import Edit
     from server.resources.executions import Executions
     from server.resources.execution import Execution
     from server.resources.execution_kill import ExecutionKill
@@ -24,6 +25,7 @@ def declare_api(app):
     api.add_resource(Platform, '/platform')
     api.add_resource(Authenticate, '/authenticate')
     api.add_resource(Register, '/users/register')
+    api.add_resource(Edit, '/users/edit')
     api.add_resource(Executions, '/executions')
     api.add_resource(ExecutionsCount, '/executions/count')
     api.add_resource(Execution, '/executions/<string:execution_identifier>')

--- a/server/common/error_codes_and_messages.py
+++ b/server/common/error_codes_and_messages.py
@@ -47,6 +47,7 @@ MISSING_PIPELINE_PROPERTY = ErrorCodeAndMessage(
     35, "'property' must be specified to use the 'propertyValue' argument")
 USERNAME_ALREADY_EXISTS = ErrorCodeAndMessage(40,
                                               "Username '{}' already exists")
+USER_DOES_NOT_EXIST = ErrorCodeAndMessage(41, "Username '{}' does not exist")
 UNAUTHORIZED = ErrorCodeAndMessage(45, "Unauthorized access")
 INVALID_PATH = ErrorCodeAndMessage(50, "Invalid pathname")
 PATH_EXISTS = ErrorCodeAndMessage(55, "File/directory already exists")

--- a/server/config.py
+++ b/server/config.py
@@ -7,11 +7,15 @@ SUPPORTED_MODULES = [
     "Processing", "Data", "AdvancedData", "Management", "Commercial"
 ]
 
+DEFAULT_PROD_DB_URI = os.path.join(basedir, 'database/app.db')
+SQLITE_DEFAULT_PROD_DB_URI = 'sqlite:///{}'.format(DEFAULT_PROD_DB_URI)
+
 
 class Config(object):
     TESTING = False
     DEBUG = False
-    SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URI')
+    SQLALCHEMY_DATABASE_URI = (os.environ.get('DATABASE_URI')
+                               or SQLITE_DEFAULT_PROD_DB_URI)
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     DATA_DIRECTORY = os.environ.get('DATA_DIRECTORY')
     PIPELINE_DIRECTORY = os.environ.get('PIPELINE_DIRECTORY')

--- a/server/resources/edit.py
+++ b/server/resources/edit.py
@@ -1,0 +1,37 @@
+from flask_restful import Resource
+from werkzeug.security import generate_password_hash
+from server.database import db
+from server.database.models.user import User, Role
+from server.common.error_codes_and_messages import (
+    UNAUTHORIZED, USER_DOES_NOT_EXIST, INVALID_MODEL_PROVIDED,
+    ErrorCodeAndMessageFormatter, ErrorCodeAndMessageAdditionalDetails)
+from .models.authentication_credentials import AuthenticationCredentialsSchema
+from .decorators import marshal_response, login_required, unmarshal_request
+
+
+class Edit(Resource):
+    @login_required
+    @unmarshal_request(AuthenticationCredentialsSchema(), partial=True)
+    @marshal_response(AuthenticationCredentialsSchema())
+    def post(self, model, user):
+        if model.password:
+            if user.role == Role.admin and model.username:
+                # Logged in user is an admin and wants to change
+                # another user's password
+                edit_user = db.session.query(User).filter_by(
+                    username=model.username).first()
+                if not edit_user:
+                    return ErrorCodeAndMessageFormatter(
+                        USER_DOES_NOT_EXIST, model.username)
+            else:
+                # Logged in user is not an admin
+                if model.username and model.username != user.username:
+                    return UNAUTHORIZED
+                edit_user = db.session.query(User).filter_by(
+                    username=user.username).first()
+            edit_user.password = generate_password_hash(model.password)
+            db.session.commit()
+        else:
+            # Password was not provided
+            return ErrorCodeAndMessageAdditionalDetails(
+                INVALID_MODEL_PROVIDED, "'password' is required")

--- a/server/resources/execution_play.py
+++ b/server/resources/execution_play.py
@@ -35,13 +35,13 @@ class ExecutionPlay(Resource):
             return UNEXPECTED_ERROR
 
         # Get the boutiques descriptor path
-        boutiques_descriptor_path, error = get_boutiques_descriptor_path(
+        boutiques_descriptor_path, error = get_original_descriptor_path(
             execution.pipeline_identifier)
         if error:
             return error
 
         # Create a version of the inputs file with correct links
-        modified_inputs_path, error = create_relative_path_inputs(
+        modified_inputs_path, error = create_absolute_path_inputs(
             user.username, execution.identifier, execution.pipeline_identifier,
             request.url_root)
 

--- a/server/resources/helpers/pipelines.py
+++ b/server/resources/helpers/pipelines.py
@@ -1,4 +1,8 @@
 import os
+try:
+    from os import scandir, walk
+except ImportError:
+    from scandir import scandir, walk
 import json
 from boutiques import bosh
 from server import app
@@ -15,7 +19,7 @@ def pipelines(pipeline_identifier: str = None,
               property_value: str = None):
     response = []
     pipeline_path = app.config['PIPELINE_DIRECTORY']
-    for subdir, dirs, files in os.walk(pipeline_path):
+    for subdir, dirs, files in walk(pipeline_path):
         if study_identifier:
             dirs[:] = [i for i in dirs if i == study_identifier]
 
@@ -53,7 +57,7 @@ def get_all_pipelines(_type: str = None) -> list:
                                           _type)
 
     all_pipelines = [
-        f for f in os.scandir(pipeline_directory)
+        f for f in scandir(pipeline_directory)
         if not f.name.startswith(".") and f.is_file()
     ]
     return all_pipelines

--- a/server/resources/helpers/register.py
+++ b/server/resources/helpers/register.py
@@ -21,7 +21,7 @@ def create_user_directory(username: str) -> (str, ErrorCodeAndMessage):
     # First let's delete user directory in case it exists
     shutil.rmtree(user_dir_absolute_path, ignore_errors=True)
 
-    # We can now creat the user directory
+    # We can now create the user directory
     path, error = create_directory(user_dir_absolute_path, False)
     if error:
         return None, error

--- a/server/startup_validation.py
+++ b/server/startup_validation.py
@@ -2,9 +2,11 @@
 which contains a description of the PlatformProperties object.
 """
 import os
+import sys
 import json
 from typing import Dict
-from .config import SUPPORTED_PROTOCOLS, SUPPORTED_MODULES
+from .config import (SUPPORTED_PROTOCOLS, SUPPORTED_MODULES,
+                     SQLITE_DEFAULT_PROD_DB_URI, DEFAULT_PROD_DB_URI)
 from .resources.models.platform_properties import PlatformPropertiesSchema
 from server import app
 from server.database import db
@@ -68,9 +70,12 @@ def pipeline_and_data_directory_present():
     if not DATA_DIRECTORY:
         raise EnvironmentError(
             "ENV['DATA_DIRECTORY'] must be set to input Data directory path")
-    if os.getenv('DATABASE_URI') is None:
-        raise EnvironmentError(
-            "ENV['DATABASE_URI'] must be set to the database URI")
+
+    if app.config['SQLALCHEMY_DATABASE_URI'] == SQLITE_DEFAULT_PROD_DB_URI:
+        print(
+            "No SQL database URI found. Reverting to default production database found at {}".
+            format(DEFAULT_PROD_DB_URI),
+            flush=True)
 
     if (not os.path.isdir(PIPELINE_DIRECTORY)
             or not os.path.isdir(DATA_DIRECTORY)):

--- a/server/startup_validation.py
+++ b/server/startup_validation.py
@@ -4,6 +4,8 @@ which contains a description of the PlatformProperties object.
 import os
 import sys
 import json
+import string
+import random
 from typing import Dict
 from .config import (SUPPORTED_PROTOCOLS, SUPPORTED_MODULES,
                      SQLITE_DEFAULT_PROD_DB_URI, DEFAULT_PROD_DB_URI)
@@ -87,10 +89,22 @@ def pipeline_and_data_directory_present():
 def find_or_create_admin():
     admin = db.session.query(User).filter_by(role=Role.admin).first()
     if not admin:
-        result, error = register_user("admin", "admin", Role.admin, db.session)
+        admin_username = "admin"
+        admin_password = generate_admin_password()
+        result, error = register_user(admin_username, admin_password,
+                                      Role.admin, db.session)
 
         if error:
             raise EnvironmentError("Could not create first admin account.")
+        separator = '-' * 20
+        print('{0} Admin Account {0}\nusername: {1}\npassword: {2}\n'.format(
+            separator, admin_username, admin_password))
+
+
+def generate_admin_password(password_length=16):
+    return ''.join(
+        random.SystemRandom().choice(string.ascii_letters + string.digits)
+        for _ in range(password_length))
 
 
 def export_pipelines():

--- a/server/test/resources/test_edit.py
+++ b/server/test/resources/test_edit.py
@@ -1,0 +1,111 @@
+import pytest
+import copy
+import json
+import os
+from server import app
+from server.common.error_codes_and_messages import (
+    USER_DOES_NOT_EXIST, UNAUTHORIZED, INVALID_MODEL_PROVIDED)
+from server.test.utils import error_from_response
+from server.test.conftest import test_client, session
+from server.test.fakedata.users import admin, standard_user, standard_user_2
+
+
+@pytest.fixture(autouse=True)
+def test_config(tmpdir_factory, session):
+    session.add(admin(True))
+    session.add(standard_user(True))
+    session.add(standard_user_2(True))
+    session.commit()
+
+    root_directory = tmpdir_factory.mktemp('data')
+    app.config['DATA_DIRECTORY'] = str(root_directory)
+
+
+class TestEditResource():
+    def test_edit_password_admin(self, test_client):
+        response = test_client.post(
+            "/users/edit",
+            headers={"apiKey": admin().api_key},
+            data=json.dumps({
+                "username": standard_user().username,
+                "password": standard_user().password + "2"
+            }))
+        assert response.status_code == 200
+
+        response = test_client.post(
+            "/authenticate",
+            data=json.dumps({
+                "username": standard_user().username,
+                "password": standard_user().password + "2"
+            }))
+        assert response.status_code == 200
+
+    def test_edit_password_user_not_exist(self, test_client):
+        response = test_client.post(
+            "/users/edit",
+            headers={"apiKey": admin().api_key},
+            data=json.dumps({
+                "username": "does_not_exist",
+                "password": standard_user().password + "2"
+            }))
+        error = error_from_response(response)
+        expected_error_code_and_message = copy.deepcopy(USER_DOES_NOT_EXIST)
+        expected_error_code_and_message.error_message = expected_error_code_and_message.error_message.format(
+            "does_not_exist")
+        assert error == expected_error_code_and_message
+
+    def test_edit_own_password_admin(self, test_client):
+        response = test_client.post(
+            "/users/edit",
+            headers={"apiKey": admin().api_key},
+            data=json.dumps({
+                "password": standard_user().password + "2"
+            }))
+        assert response.status_code == 200
+
+        response = test_client.post(
+            "/authenticate",
+            data=json.dumps({
+                "username": admin().username,
+                "password": standard_user().password + "2"
+            }))
+        assert response.status_code == 200
+
+    def test_edit_password_user(self, test_client):
+        response = test_client.post(
+            "/users/edit",
+            headers={"apiKey": standard_user().api_key},
+            data=json.dumps({
+                "password": standard_user().password + "2"
+            }))
+        assert response.status_code == 200
+
+        response = test_client.post(
+            "/authenticate",
+            data=json.dumps({
+                "username": standard_user().username,
+                "password": standard_user().password + "2"
+            }))
+        assert response.status_code == 200
+
+    def test_edit_password_user_other_user(self, test_client):
+        response = test_client.post(
+            "/users/edit",
+            headers={"apiKey": standard_user().api_key},
+            data=json.dumps({
+                "username": standard_user_2().username,
+                "password": standard_user().password + "2"
+            }))
+        error = error_from_response(response)
+        assert error == UNAUTHORIZED
+
+    def test_edit_password_no_password(self, test_client):
+        response = test_client.post(
+            "/users/edit",
+            headers={"apiKey": standard_user().api_key},
+            data=json.dumps({
+                "password": ""
+            }))
+        error = error_from_response(response)
+        INVALID_MODEL_PROVIDED.error_detail = "'password' is required"
+        assert error == INVALID_MODEL_PROVIDED

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ DEPS = [
     "flask-restful>=0.3.6,<1.0", "flask-sqlalchemy>-2.3.2,<3.0",
     "psycopg2-binary>=2.7.4,<3.0", "marshmallow>=2.15.0,<3.0",
     "marshmallow_enum>=1.4.1,<2.0", "boutiques>=0.5.6,<1.0",
-    "blinker>=1.4,<2.0"
+    "blinker>=1.4,<2.0", "typing>=3.6.4,<4.0", "scandir>=1.7,<2.0"
 ]
 
 setup(


### PR DESCRIPTION
PR Includes:
- Launch server with SQLite database if no `DATABASE_URI` specified (with accompanying documentation)
- Add support for Python 3.4
- Add ability to change users's passwords (with accompanying documentation)
  - Admin can change any user's password, users can change their own
- Instead of using default `'admin':'admin'` login information, generate a random password and print to console during first server launch